### PR TITLE
Added Unregister-PSResourceRepository for cleanup 

### DIFF
--- a/src/steps/4_publish_to_nuget.ps1
+++ b/src/steps/4_publish_to_nuget.ps1
@@ -4,4 +4,6 @@ Register-PSResourceRepository -Name "NuGet" -Uri $env:INPUT_NUGETURL -Trusted
 Write-Host "Publishing to NuGet repository...."
 Publish-PSResource -Path $env:RESOLVED_PATH -Repository "NuGet" -ApiKey $env:INPUT_TOKEN
 
+Unregister-PSResourceRepository -Name "NuGet"
+
 Write-Host "Done!"


### PR DESCRIPTION
At the beginning of the process, the repository is registered. 
If you try to publish again, the process fails because the repository is already registered.
I have added a cleanup line to unregister the repository after publishing. 
